### PR TITLE
Replace target_url with log_url and allow user to customize it

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ jobs:
         id: deployment
         with:
           token: "${{ github.token }}"
+          environment_url: http://my-app-url.com
           environment: production
 
       - name: Deploy my app

--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ jobs:
         id: deployment
         with:
           token: "${{ github.token }}"
-          target_url: http://my-app-url.com
           environment: production
 
       - name: Deploy my app
@@ -50,7 +49,7 @@ jobs:
         uses: chrnorm/deployment-status@releases/v1
         with:
           token: "${{ github.token }}"
-          target_url: http://my-app-url.com
+          environment_url: http://my-app-url.com
           state: "success"
           deployment_id: ${{ steps.deployment.outputs.deployment_id }}
 
@@ -59,7 +58,7 @@ jobs:
         uses: chrnorm/deployment-status@releases/v1
         with:
           token: "${{ github.token }}"
-          target_url: http://my-app-url.com
+          environment_url: http://my-app-url.com
           state: "failure"
           deployment_id: ${{ steps.deployment.outputs.deployment_id }}
 ```

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Works great with my other action to create Deployments, [chrnorm/deployment-acti
 | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
 | `state`           | The state to set the deployment to. Must be one of the below: "error" "failure" "inactive" "in_progress" "queued" "pending" "success" |
 | `token`           | GitHub token                                                                                                                          |
-| `target_url`      | (Optional) The target URL. This should be the URL of the app once deployed                                                            |
+| `log_url`         | (Optional) Sets the URL for deployment output                                                                                         |
 | `description`     | (Optional) Descriptive message about the deployment                                                                                   |
 | `environment_url` | (Optional) Sets the URL for accessing your environment                                                                                |
 | `deployment_id`   | The ID of the deployment to update                                                                                                    |

--- a/action.yml
+++ b/action.yml
@@ -11,8 +11,11 @@ inputs:
   token:
     description: "Github repository token"
     required: true
+  log_url:
+    description: "Sets the URL for deployment output"
+    required: false
   target_url:
-    description: "Target url location"
+    description: "Same as log_url"
     required: false
   environment_url:
     description: "Sets the URL for accessing your environment"

--- a/lib/main.js
+++ b/lib/main.js
@@ -21,15 +21,15 @@ function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
             const context = github.context;
-            const defaultUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/commit/${context.sha}/checks`;
+            const defaultLogUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/commit/${context.sha}/checks`;
             const token = core.getInput("token", { required: true });
-            const url = core.getInput("target_url", { required: false }) || defaultUrl;
+            const logUrl = core.getInput("log_url", { required: false }) || core.getInput("target_url", { required: false }) || defaultLogUrl;
             const description = core.getInput("description", { required: false }) || "";
             const deploymentId = core.getInput("deployment_id");
             const environmentUrl = core.getInput("environment_url", { required: false }) || "";
             const state = core.getInput("state");
             const client = new github.GitHub(token, { previews: ["flash", "ant-man"] });
-            yield client.repos.createDeploymentStatus(Object.assign({}, context.repo, { deployment_id: parseInt(deploymentId), state, log_url: defaultUrl, target_url: url, description, environment_url: environmentUrl }));
+            yield client.repos.createDeploymentStatus(Object.assign({}, context.repo, { deployment_id: parseInt(deploymentId), state, log_url: logUrl, description, environment_url: environmentUrl }));
         }
         catch (error) {
             core.error(error);

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,10 +13,10 @@ type DeploymentState =
 async function run() {
   try {
     const context = github.context;
-    const defaultUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/commit/${context.sha}/checks`;
+    const defaultLogUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/commit/${context.sha}/checks`;
 
     const token = core.getInput("token", { required: true });
-    const url = core.getInput("target_url", { required: false }) || defaultUrl;
+    const logUrl = core.getInput("log_url", { required: false }) || core.getInput("target_url", { required: false }) || defaultLogUrl;
     const description = core.getInput("description", { required: false }) || "";
     const deploymentId = core.getInput("deployment_id");
     const environmentUrl =
@@ -29,8 +29,7 @@ async function run() {
       ...context.repo,
       deployment_id: parseInt(deploymentId),
       state,
-      log_url: defaultUrl,
-      target_url: url,
+      log_url: logUrl,
       description,
       environment_url: environmentUrl,
     });


### PR DESCRIPTION
- [log_url replaces target_url](https://docs.github.com/en/free-pro-team@latest/rest/reference/repos#create-a-deployment-status)
- `log_url` was always `defaultUrl`, this PR fixes it
  - I'm using this action in pull_request event, but its sha points to `Merge [HEAD] to [BASE]` commit instead of PR head; /checks URL shows empty result https://github.com/actions/checkout/issues/281#issue-639739078
  - For workaround, use `log_url: https://github.com/${{ github.repository }}/commit/${{ github.event.pull_request.head.sha }}/checks`
- Also fixes "View Deployment" button did not appear with example in README.md.