### PR TITLE
Use Node 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -41,5 +41,5 @@ inputs:
     description: 'Changes the API base URL for a GitHub Enterprise server.'
     required: false
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
Fixes warning like: `Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: chrnorm/deployment-status`