### PR TITLE
Update to run on Node16.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -41,5 +41,5 @@ inputs:
     description: 'Changes the API base URL for a GitHub Enterprise server.'
     required: false
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
Summary
-------

GHA is deprecating support for Node 12 on actions: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

This PR bumps the node version up to 16 per their recommendations. 